### PR TITLE
Add `bits` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,8 @@ pairing = "0.23"
 blake2b_simd = "1"
 
 [features]
-default = [ "reexport" ]
+default = [ "reexport", "bits" ]
+bits = ["ff/bits"]
 asm = []
 prefetch = []
 print-trace = [ "ark-std/print-trace" ]

--- a/src/tests/field.rs
+++ b/src/tests/field.rs
@@ -254,3 +254,20 @@ where
     }
     end_timer!(start);
 }
+
+#[cfg(feature = "bits")]
+pub fn random_bits_tests<F: ff::PrimeFieldBits>(type_name: String) {
+    let mut rng = XorShiftRng::from_seed([
+        0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc,
+        0xe5,
+    ]);
+    let _message = format!("to_le_bits {type_name}");
+    for _ in 0..1000000 {
+        let a = F::random(&mut rng);
+        let bytes = a.to_repr();
+        let bits = a.to_le_bits();
+        for idx in 0..bits.len() {
+            assert_eq!(bits[idx], ((bytes.as_ref()[idx / 8] >> (idx % 8)) & 1) == 1);
+        }
+    }
+}


### PR DESCRIPTION
# Description

The `bits` feature was thought to be unnecessary and was removed. Turns out the trait `ff::PrimeFieldBits` is implemented under this feature so it is necessary to bring it back.

The [latest release](https://github.com/privacy-scaling-explorations/halo2curves/releases/tag/v0.6.0) of the library already supports the feature so there is no need to open a PR there.

# Changes
 - `bits` feature added and set to default
 - Added `random_bits_tests`.